### PR TITLE
add DefaultRoborazziOptions

### DIFF
--- a/app/src/main/java/com/example/screenshotpractice/MainActivity.kt
+++ b/app/src/main/java/com/example/screenshotpractice/MainActivity.kt
@@ -27,7 +27,7 @@ fun MainScreen() {
         modifier = Modifier.fillMaxSize(),
         color = Color.White
     ) {
-        Text(text = "Hello Android!\nHello Android!")
+        Text(text = "Hello Android!\nHello Android!\nHello Android!")
     }
 }
 

--- a/app/src/main/java/com/example/screenshotpractice/MainActivity.kt
+++ b/app/src/main/java/com/example/screenshotpractice/MainActivity.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 
 class MainActivity : ComponentActivity() {
@@ -24,9 +25,9 @@ class MainActivity : ComponentActivity() {
 fun MainScreen() {
     Surface(
         modifier = Modifier.fillMaxSize(),
-        color = MaterialTheme.colorScheme.background
+        color = Color.White
     ) {
-        Text(text = "Hello Android!")
+        Text(text = "Hello Android!\nHello Android!")
     }
 }
 

--- a/app/src/test/java/com/example/screenshotpractice/MainActivityTest.kt
+++ b/app/src/test/java/com/example/screenshotpractice/MainActivityTest.kt
@@ -30,6 +30,8 @@ class MainActivityTest {
     private fun captureMainActivity() {
         composeTestRule
             .onRoot()
-            .captureRoboImage()
+            .captureRoboImage(
+                roborazziOptions = DefaultRoborazziOptions,
+            )
     }
 }

--- a/app/src/test/java/com/example/screenshotpractice/ScreenshotHelper.kt
+++ b/app/src/test/java/com/example/screenshotpractice/ScreenshotHelper.kt
@@ -1,0 +1,9 @@
+package com.example.screenshotpractice
+
+import com.github.takahirom.roborazzi.RoborazziOptions
+
+val DefaultRoborazziOptions =
+    RoborazziOptions(
+        compareOptions = RoborazziOptions.CompareOptions(changeThreshold = 0f), // Pixel-perfect matching
+        recordOptions = RoborazziOptions.RecordOptions(resizeScale = 0.5), // Reduce the size of the PNGs
+    )


### PR DESCRIPTION
```
// 比較前の状態を保存
./gradlew recordRoborazziDebug

// レイアウトを書き換えて比較
./gradlew compareRoborazziDebug
```

Text の文言を変えても unchanged になってしまい、背景色を変えたら compare が反応している

<img src = https://github.com/morux2/RoborazziPractice/assets/19369161/084ac068-75e6-4c14-8f38-508ae3d65400 width = 400>



