### PR TITLE
./gradlew recordRoborazziDebug Failed

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -84,4 +84,9 @@ dependencies {
     // showkase
     implementation "com.airbnb.android:showkase:1.0.0-beta18"
     ksp "com.airbnb.android:showkase-processor:1.0.0-beta18"
+
+    // sharedPref
+    implementation("androidx.security:security-crypto:1.0.0")
+    implementation("androidx.security:security-identity-credential:1.0.0-alpha03")
+    implementation("androidx.security:security-app-authenticator:1.0.0-alpha02")
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <application
+        android:name=".SampleApp"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/example/screenshotpractice/MainActivity.kt
+++ b/app/src/main/java/com/example/screenshotpractice/MainActivity.kt
@@ -4,28 +4,16 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.security.crypto.EncryptedSharedPreferences
-import androidx.security.crypto.MasterKeys
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        val mainKey = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC)
-        EncryptedSharedPreferences.create(
-            "hoge",
-            mainKey,
-            this@MainActivity,
-            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-        )
 
         setContent {
             MainScreen()

--- a/app/src/main/java/com/example/screenshotpractice/MainActivity.kt
+++ b/app/src/main/java/com/example/screenshotpractice/MainActivity.kt
@@ -11,10 +11,22 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKeys
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        val mainKey = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC)
+        EncryptedSharedPreferences.create(
+            "hoge",
+            mainKey,
+            this@MainActivity,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+
         setContent {
             MainScreen()
         }

--- a/app/src/main/java/com/example/screenshotpractice/SampleApp.kt
+++ b/app/src/main/java/com/example/screenshotpractice/SampleApp.kt
@@ -1,0 +1,19 @@
+package com.example.screenshotpractice
+
+import android.app.Application
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKeys
+
+class SampleApp : Application() {
+    override fun onCreate() {
+        val mainKey = MasterKeys.getOrCreate(MasterKeys.AES256_GCM_SPEC)
+        EncryptedSharedPreferences.create(
+            "hoge",
+            mainKey,
+            this,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
+        super.onCreate()
+    }
+}

--- a/app/src/test/java/com/example/screenshotpractice/DummyApp.kt
+++ b/app/src/test/java/com/example/screenshotpractice/DummyApp.kt
@@ -1,0 +1,5 @@
+package com.example.screenshotpractice
+
+import android.app.Application
+
+class DummyApp : Application()

--- a/app/src/test/java/com/example/screenshotpractice/ShowkaseScreenshotTest.kt
+++ b/app/src/test/java/com/example/screenshotpractice/ShowkaseScreenshotTest.kt
@@ -14,7 +14,10 @@ import org.robolectric.annotation.GraphicsMode
 // https://github.com/DroidKaigi/conference-app-2023/pull/217
 @RunWith(ParameterizedRobolectricTestRunner::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
-@Config(qualifiers = RobolectricDeviceQualifiers.MediumTablet)
+@Config(
+    qualifiers = RobolectricDeviceQualifiers.MediumTablet,
+    application = DummyApp::class
+    )
 class ShowkaseScreenshotTest(
     private val showkaseBrowserComponent: ShowkaseBrowserComponent,
 ) {


### PR DESCRIPTION
```
java.security.KeyStoreException: AndroidKeyStore not found
Caused by: java.security.NoSuchAlgorithmException: AndroidKeyStore KeyStore not available
```

MainActivityTestはこけているが、ShowkaseScreenshotTestはこけない

---
(追記)
EncryptedSharedPrefの呼び出しもとをApplicationクラスに変えたら全てのテストがFailした
