### PR TITLE
add custom annotation

### DIFF
--- a/app/src/main/java/com/example/screenshotpractice/LongContentActivity.kt
+++ b/app/src/main/java/com/example/screenshotpractice/LongContentActivity.kt
@@ -5,14 +5,10 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
 
 class LongContentActivity : ComponentActivity() {
@@ -40,7 +36,7 @@ fun LongContentScreen() {
     }
 }
 
-@Preview(name = "LongContentScreenPreview", group = "LongContentScreen", showBackground = true)
+@MyPreview
 @Composable
 fun LongContentScreenPreview() {
     LongContentScreen()

--- a/app/src/main/java/com/example/screenshotpractice/MainActivity.kt
+++ b/app/src/main/java/com/example/screenshotpractice/MainActivity.kt
@@ -31,7 +31,7 @@ fun MainScreen() {
     }
 }
 
-@Preview(name = "MainScreenPreview", group = "MainScreen", showBackground = true)
+@MyPreview
 @Composable
 fun MainScreenPreview() {
     MainScreen()

--- a/app/src/main/java/com/example/screenshotpractice/MyPreview.kt
+++ b/app/src/main/java/com/example/screenshotpractice/MyPreview.kt
@@ -1,0 +1,7 @@
+package com.example.screenshotpractice
+
+import androidx.compose.ui.tooling.preview.Preview
+
+@Preview(group = "MyPreview", device = "id:Nexus 9")
+@Preview(group = "MyPreview", device = "id:pixel_c")
+public annotation class MyPreview

--- a/app/src/test/java/com/example/screenshotpractice/ShowkaseScreenshotTest.kt
+++ b/app/src/test/java/com/example/screenshotpractice/ShowkaseScreenshotTest.kt
@@ -1,6 +1,5 @@
 package com.example.screenshotpractice
 
-import androidx.compose.runtime.Composable
 import com.airbnb.android.showkase.models.Showkase
 import com.airbnb.android.showkase.models.ShowkaseBrowserComponent
 import com.github.takahirom.roborazzi.DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH

--- a/app/src/test/java/com/example/screenshotpractice/ShowkaseScreenshotTest.kt
+++ b/app/src/test/java/com/example/screenshotpractice/ShowkaseScreenshotTest.kt
@@ -1,5 +1,6 @@
 package com.example.screenshotpractice
 
+import androidx.compose.runtime.Composable
 import com.airbnb.android.showkase.models.Showkase
 import com.airbnb.android.showkase.models.ShowkaseBrowserComponent
 import com.github.takahirom.roborazzi.DEFAULT_ROBORAZZI_OUTPUT_DIR_PATH
@@ -35,7 +36,11 @@ class ShowkaseScreenshotTest(
         @ParameterizedRobolectricTestRunner.Parameters
         @JvmStatic
         fun components(): Iterable<Array<Any?>> {
-            return Showkase.getMetadata().componentList.map { showkaseBrowserComponent ->
+            return Showkase.getMetadata().componentList.map {
+                it.copy(componentName = it.componentName.split(" ")[0])
+            }.distinctBy {
+                it.componentName
+            }.map { showkaseBrowserComponent ->
                 arrayOf(showkaseBrowserComponent)
             }
         }


### PR DESCRIPTION
![スクリーンショット 2023-10-29 10 18 52](https://github.com/morux2/RoborazziPractice/assets/19369161/dd45f7e0-b6fa-4407-a08b-e56bb9081783)

ShowkaseがCustomAnnotationに対応したが、アノテーションの数だけ結果が吐き出されてしまうので、各Previewで1つだけ出力されるようにFilterをかけたい。